### PR TITLE
fix #1 bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+data/
 /target
 **/*.rs.bk
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ use sonic_client::SearchChan;
 
 let mut s = SearchChan::new("127.0.0.1", 1491, "haha").expect("Connection error");
 let handle = s.read();
-assert_eq!("CONNECTED <sonic-server v1.1.8>\r\n", s.connect().unwrap());
+assert_eq!("CONNECTED <sonic-server v1.2.3>", s.connect().unwrap());
 thread::sleep(time::Duration::from_secs(4));
 let r1 = s
     .query("helpdesk", "user:0dcde3a6", "gdpr", Some(50), None)
@@ -25,8 +25,8 @@ let r1 = s
 let r2 = s.ping().unwrap();
 let r3 = s.quit().unwrap();
 assert_eq!("EVENT", r1[0]);
-assert_eq!("PONG\r\n", r2.recv().unwrap());
-assert_eq!("ENDED quit\r\n", r3.recv().unwrap());
+assert_eq!("PONG", r2.recv().unwrap());
+assert_eq!("ENDED quit", r3.recv().unwrap());
 handle.join().expect("Failed to wait process");
 ```
 

--- a/config.cfg
+++ b/config.cfg
@@ -6,7 +6,7 @@
 
 [server]
 
-log_level = "error"
+log_level = "debug"
 
 
 [channel]

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,4 @@
+mkdir -p sonic/store
+DIR=`pwd`
+docker run -d -p 1491:1491 --name sonic -v $DIR/config.cfg:/etc/sonic.cfg -v $DIR/sonic/store/:/var/lib/sonic/store/ valeriansaliou/sonic:v1.2.3
+

--- a/src/control.rs
+++ b/src/control.rs
@@ -53,7 +53,7 @@ impl ControlChan {
         let is_debugging = Arc::new(self.debugging);
         thread::spawn(move || {
             let poll = mio::Poll::new().unwrap();
-            poll.register(&conn, CLIENT, Ready::readable(), PollOpt::edge())
+            poll.register(&conn, CLIENT, Ready::readable(), PollOpt::level())
                 .unwrap();
             let mut events = Events::with_capacity(1024);
             let mut reader = BufReader::new(&conn);
@@ -163,10 +163,10 @@ mod test {
     use super::*;
     use std::time;
     #[test]
-    fn test_search() {
+    fn test_control() {
         let mut s = ControlChan::new("127.0.0.1", 1491, "haha").expect("Connection error");
         let handle = s.read();
-        assert_eq!("CONNECTED <sonic-server v1.1.8>\r\n", s.connect().unwrap());
+        assert_eq!("CONNECTED <sonic-server v1.2.3>\r\n", s.connect().unwrap());
         thread::sleep(time::Duration::from_secs(4));
         let r2 = s.ping().unwrap();
         let r3 = s.quit().unwrap();

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -53,7 +53,7 @@ impl IngestChan {
         let is_debugging = Arc::new(self.debugging);
         thread::spawn(move || {
             let poll = mio::Poll::new().unwrap();
-            poll.register(&conn, CLIENT, Ready::readable(), PollOpt::edge())
+            poll.register(&conn, CLIENT, Ready::readable(), PollOpt::level())
                 .unwrap();
             let mut events = Events::with_capacity(1024);
             let mut reader = BufReader::new(&conn);
@@ -236,7 +236,7 @@ mod test {
         let mut s = IngestChan::new("127.0.0.1", 1491, "haha").expect("Connection error");
         s.debug();
         let handle = s.read();
-        assert_eq!("CONNECTED <sonic-server v1.1.8>\r\n", s.connect().unwrap());
+        assert_eq!("CONNECTED <sonic-server v1.2.3>\r\n", s.connect().unwrap());
         thread::sleep(time::Duration::from_secs(4));
         let r1 = s
             .push(


### PR DESCRIPTION
sonic-server now is v1.2.3. Original code adapt server version 1.1.8.
when send query command, server response with PENDING and then return EVENT QUEY xxxxx.  Original code has some bug for process this condition.
1. BufferedReader.read_line  in poll() will miss EVENT QUEY xxxxx in the condition that server return two lines data.
2. ` receiver.recv()`  in query fn has race conditions , cause cannot process EVENT QUEY xxxxx. and process hang.
3. add docker script for test.


